### PR TITLE
Add none as default or optional refinement controller

### DIFF
--- a/applications/solvers/additiveFoam/additiveFoam.C
+++ b/applications/solvers/additiveFoam/additiveFoam.C
@@ -103,7 +103,6 @@ int main(int argc, char *argv[])
         timer.start("Refinement Control and Mesh Update");
         if (sources.refinementControl().update())
         {
-            Info << "Calling mesh.update()" << endl;
             mesh.update();
         }
         timer.stop("Refinement Control and Mesh Update");

--- a/applications/solvers/additiveFoam/movingHeatSource/Make/files
+++ b/applications/solvers/additiveFoam/movingHeatSource/Make/files
@@ -14,6 +14,7 @@ heatSourceModels/modifiedSuperGaussian/modifiedSuperGaussian.C
 
 refinementControllers/refinementController/refinementController.C
 refinementControllers/refinementController/refinementControllerNew.C
+refinementControllers/noRefinementController/noRefinementController.C
 refinementControllers/uniformIntervals/uniformIntervals.C
 
 movingHeatSourceModel/movingHeatSourceModel.C

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/noRefinementController/noRefinementController.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/noRefinementController/noRefinementController.C
@@ -25,49 +25,30 @@ License
 
 \*---------------------------------------------------------------------------*/
 
-#include "refinementController.H"
+#include "noRefinementController.H"
+#include "addToRunTimeSelectionTable.H"
 
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
-Foam::autoPtr<Foam::refinementController> Foam::refinementController::New
+namespace Foam
+{
+namespace refinementControllers
+{
+    defineTypeNameAndDebug(noRefinementController, 0);
+    addToRunTimeSelectionTable(refinementController, noRefinementController, dictionary);
+}
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::refinementControllers::noRefinementController::noRefinementController
 (
     const PtrList<heatSourceModel>& sources,
     const dictionary& dict,
     const fvMesh& mesh
 )
-{
-    //- Initialize modelType to a non-model word
-    word modelType("none");
-    
-    //- Get model type from refinement control subdict
-    dictionary refinementControlDict(dict.optionalSubDict("refinementControl"));
-    
-    modelType =
-        refinementControlDict.lookupOrDefault<word>
-        (
-            "refinementController",
-            "none"
-        );
-
-    Info<< "Selecting refinement control model " << modelType << endl;
-
-    //- Look up model type from runtime selection table and throw error
-    //  if it doesn't exist
-    dictionaryConstructorTable::iterator cstrIter =
-        dictionaryConstructorTablePtr_->find(modelType);
-
-    if (cstrIter == dictionaryConstructorTablePtr_->end())
-    {
-        FatalErrorInFunction
-            << "Unknown " << refinementController::typeName<< " type "
-            << modelType << nl << nl
-            << "Valid  refinementControllers are : " << endl
-            << dictionaryConstructorTablePtr_->sortedToc()
-            << exit(FatalError);
-    }
-
-    return autoPtr<refinementController>(cstrIter()(sources, dict, mesh));
-}
-
+:
+    refinementController(typeName, sources, dict, mesh)
+{}
 
 // ************************************************************************* //

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/noRefinementController/noRefinementController.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/noRefinementController/noRefinementController.H
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2022 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+                Copyright (C) 2023 Oak Ridge National Laboratory                
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::refinementControllers::none
+
+Description
+    This refinement control scheme divides the simulation into an even
+    number of intervals equal to the simulation end time divided by the
+    number of intervals. Refinement for each beam is carried out on each
+    interval.
+
+SourceFiles
+    none.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef noRefinementController_H
+#define noRefinementController_H
+
+#include "refinementController.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace refinementControllers
+{
+
+/*---------------------------------------------------------------------------*\
+                          Class noRefinementController
+\*---------------------------------------------------------------------------*/
+
+class noRefinementController
+:
+    public refinementController
+{
+
+public:
+
+    //- Runtime type information
+    TypeName("none");
+
+
+    // Constructors
+
+        //- Default empty constructor
+        noRefinementController
+        (
+            const PtrList<heatSourceModel>& sources,
+            const dictionary& dict,
+            const fvMesh& mesh
+        );
+
+
+    //- Destructor
+    virtual ~noRefinementController()
+    {}
+
+
+    // Member Functions
+
+        //- Always return true to allow mesh.update() to work uninterupted
+        virtual bool update()
+        {
+            return true;
+        }
+
+        //- Return true always
+        virtual bool read()
+        {
+            return true;
+        }
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace refinementControllers
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/refinementController/refinementController.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/refinementController/refinementController.C
@@ -85,7 +85,7 @@ Foam::refinementController::refinementController
     heatSourceDict_(dict),
     mesh_(mesh),
     refinementDict_(heatSourceDict_.optionalSubDict("refinementControl")),
-    refine_(refinementDict_.lookup<bool>("refine")),
+    refine_((type != "none") ? refinementDict_.lookup<bool>("refine") : false),
     refinementField_
     (
         IOobject
@@ -117,7 +117,7 @@ Foam::refinementController::refinementController
         dimensionedScalar(dimless, -GREAT)
     ),
     lastRefinementIndex_(0),
-    nLevels_(refinementDict_.lookup<label>("nLevels"))
+    nLevels_((type != "none") ? refinementDict_.lookup<label>("nLevels") : 0)
 {
 }
 

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
@@ -151,11 +151,6 @@ bool Foam::refinementControllers::uniformIntervals::update()
                 scalar beamMode = sources_[i].beam().mode(beamTime);
                 scalar timeToNext = sources_[i].beam().timeToNextPath(beamTime);
                 
-                Info << "Current sim time: " << currTime << endl;
-                Info << "Current beam time: " << beamTime << endl;
-                Info << "Current path: " << sources_[i].beam().findIndex(beamTime) << endl;
-                Info << "Current timeToNext: " << timeToNext << endl;
-                
                 if (beamMode == 0.0)
                 {
                     beamDt = sources_[i].D2sigma()
@@ -166,8 +161,6 @@ bool Foam::refinementControllers::uniformIntervals::update()
                     {         
                         beamDt = min(beamDt, timeToNext - 1e-8);
                     }
-                    
-                    Info << "Beam Mode 0: Using beamDt = " << beamDt << endl;
                 }
                 
                 else
@@ -175,8 +168,6 @@ bool Foam::refinementControllers::uniformIntervals::update()
                     beamDt = timeToNext + 1e-8; // this extra tolerance is needed 
                                                 // so that mode 0 paths don't get
                                                 // skipped following a mode 1 path
-                    
-                    Info << "Beam Mode 1: Using beamDt = " << beamDt << endl;
                 }
                 
                 //- Ensure end of interval gets refined
@@ -185,8 +176,6 @@ bool Foam::refinementControllers::uniformIntervals::update()
                 if (abs(beamTime - updateTime_) > 1e-6)
                 {
                     beamTime = min(beamTime, updateTime_ - 1e-8);
-                    
-                    Info << "Forcing final update before updateTime" << endl;
                 }
             }            
         }

--- a/tutorials/AMB2018-02-B/README.md
+++ b/tutorials/AMB2018-02-B/README.md
@@ -8,8 +8,10 @@ The standard tutorial uses the `superGaussian` heat source model and can be run 
 ### AMR Tutorial
 The AMR tutorial incorporates adaptive mesh refinement coupled with the `refinementController` class implemented in AdditiveFOAM. For effective AMR, the [Zoltan](https://sandialabs.github.io/Zoltan) must be compiled with OpenFOAM. This can be accomplished by rerunning the ThirdParty Allwmake script with the [Zoltan 3.90 tarball](https://github.com/sandialabs/Zoltan/archive/refs/tags/v3.90.tar.gz) present in the ThirdParty directory.
 
-In addition to compiling Zoltan, two files must be changed from the standard tutorial. First, the included `dynamicMeshDictAMR` file should be renamed to `dynamicMeshDict`:
+In addition to compiling Zoltan, three files must be changed from the standard tutorial. First, the included `dynamicMeshDictAMR` file should be renamed to `dynamicMeshDict`:
 
 `$ mv constant/dynamicMeshDictAMR constant/dynamicMeshDict`
 
-This will activate OpenFOAM's AMR capability. In additon, the `system/decomposeParDict` should be modified to use the `hierachical` decomposer with `zoltan` as the distributor. The `scotch` decomposer entry should be commented or removed. Be sure to include the `libzoltanDecomp.so` file and define appropriate entries for the decomposer and distributor. The `refinementHistory` constrain will ensure that all refined cells originating from a single parent cell remain on the same processor throughout the load distribution process.
+Then, change the `refinementController` entry from `none` to `uniformIntervals` within the `constant/heatSourceModels` file.
+
+In additon, the `system/decomposeParDict` should be modified to use the `hierachical` decomposer with `zoltan` as the distributor. The `scotch` decomposer entry should be commented or removed. Be sure to include the `libzoltanDecomp.so` file and define appropriate entries for the decomposer and distributor. The `refinementHistory` constrain will ensure that all refined cells originating from a single parent cell remain on the same processor throughout the load distribution process.

--- a/tutorials/AMB2018-02-B/constant/heatSourceDict
+++ b/tutorials/AMB2018-02-B/constant/heatSourceDict
@@ -46,7 +46,8 @@ refinementControl
     resolveTail             true;
     persistence             1e-4;
     
-    refinementController    uniformIntervals;
+    refinementController    none;
+    //refinementController    uniformIntervals;
     
     uniformIntervalsCoeffs
     {


### PR DESCRIPTION
This PR implements a `none` option for the refinement controller to maintain backwards compatibility with old AdditiveFOAM cases. In instances where no `refinementController` dictionary is present, a default `none` class is called which performs no calculations and always returns `true` when the `update()` function is called, to allow other mesh changes to occur as expected.

In addition to the `none` option, several other files have been cleaned up to reduce unnecessary output to the log file.