### PR TITLE
Resource-Optimized AMR

### DIFF
--- a/applications/solvers/additiveFoam/movingHeatSource/Make/files
+++ b/applications/solvers/additiveFoam/movingHeatSource/Make/files
@@ -16,6 +16,7 @@ refinementControllers/refinementController/refinementController.C
 refinementControllers/refinementController/refinementControllerNew.C
 refinementControllers/noRefinementController/noRefinementController.C
 refinementControllers/uniformIntervals/uniformIntervals.C
+refinementControllers/ROAMR/ROAMR.C
 
 movingHeatSourceModel/movingHeatSourceModel.C
 

--- a/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.C
@@ -55,6 +55,7 @@ Foam::movingBeam::movingBeam
     position_(Zero),
     power_(0.0),
     endTime_(0.0),
+    length_(0.0),
     deltaT_(GREAT),
     hitPathIntervals_(true)
 {
@@ -278,6 +279,8 @@ void Foam::movingBeam::readPath()
         else
         {
             scalar d_ = mag(path_[i].position() - path_[i-1].position());
+            
+            length_ += d_;
                     
             path_[i].setTime
             (

--- a/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.H
@@ -88,6 +88,9 @@ private:
         //- End time of path
         scalar endTime_;
         
+        //- Total length of path
+        scalar length_;
+        
         //- Time step used for heat source integration
         scalar deltaT_;
         
@@ -160,6 +163,18 @@ public:
         inline scalar power() const
         {
             return power_;
+        }
+        
+        //- Return the path end time
+        inline scalar endTime() const
+        {
+            return endTime_;
+        }
+        
+        //- Return total path length
+        inline scalar length() const
+        {
+            return length_;
         }
         
         scalar deltaT() const

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.C
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2022 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+                Copyright (C) 2023 Oak Ridge National Laboratory                
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "ROAMR.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace refinementControllers
+{
+    defineTypeNameAndDebug(ROAMR, 0);
+    addToRunTimeSelectionTable(refinementController, ROAMR, dictionary);
+}
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::refinementControllers::ROAMR::ROAMR
+(
+    const PtrList<heatSourceModel>& sources,
+    const dictionary& dict,
+    const fvMesh& mesh
+)
+:
+    uniformIntervals(sources, dict, mesh, true),
+    
+    coeffs_(refinementDict_.optionalSubDict(typeName + "Coeffs")),
+    cellsPerProc_(coeffs_.lookupOrDefault<int>("cellsPerProc", 20000))
+{
+    //- Take first guess at interval size
+    Info << "Calculating initial AMR interval size..." << endl;
+    
+    //- Get average cell volume and cross-sectional area
+    scalar vAvg = gSum(mesh_.V()) / mesh_.nCells();
+    
+    //- Get approximate cross-sectional area of each beam
+    scalar scanArea = 0.0;
+    scalar maxLen = 0.0;
+    scalar scanEnd = 0.0;
+    forAll(sources_, i)
+    {
+        scanArea += boundingBox_ / 2.0 
+                    * max
+                      (
+                        sources_[i].dimensions().x(),
+                        sources_[i].dimensions().y()
+                      )                    
+                    * sources_[i].dimensions().z();
+                    
+        maxLen = max(sources_[i].beam().length(), maxLen);
+        scanEnd = max(sources_[i].beam().endTime(), scanEnd);
+    }
+    
+    //- Calculate number of intervals to optimize cells per processor
+    scalar targetCells = Pstream::nProcs() * cellsPerProc_;
+    
+    if (targetCells > mesh_.nCells())
+    {
+        intervals_ = maxLen * scanArea / vAvg / (targetCells - mesh_.nCells())
+                     * (Foam::pow(2.0, 3.0 * nLevels_) - 1.0);
+    }
+    
+    // Enforce nInvervals >= 1
+    intervals_ = max(intervals_, 1.0);
+    
+    Info << "Settiing initial number of intervals to: " << intervals_ << endl;
+    
+    //- Set number of intervals in uniformIntervals class    
+    intervalSize_ = scanEnd / intervals_;
+    
+    Info << "Setting initial interval size to: " << intervalSize_ << endl;
+}
+
+
+// * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
+
+bool Foam::refinementControllers::ROAMR::update()
+{
+    //- Scale interval size based on current cells/proc
+    scalar currCellsPerProc = mesh_.nCells() / Pstream::nProcs();
+    
+    Info << "Current cells per processor: " << currCellsPerProc << endl;
+    
+    if (currCellsPerProc < cellsPerProc_)
+    {
+        intervalSize_ =
+            min
+            (
+                intervalSize_ * cellsPerProc_ / currCellsPerProc,
+                1.1 * intervalSize_
+            );
+    }
+    else
+    {
+        intervalSize_ =
+            max
+            (
+                intervalSize_ * currCellsPerProc / cellsPerProc_,
+                0.9 * intervalSize_
+            );
+    }
+    
+    //- Update refinement field using uniform intervals functions
+    if (uniformIntervals::update())
+    {
+        Info << "Recalculating AMR interval size to target " << cellsPerProc_
+         << " cells per processor." << endl;
+        
+        return true;
+    }
+    
+    else
+    {
+        return false;
+    }
+}
+
+
+bool Foam::refinementControllers::ROAMR::read()
+{
+    if (uniformIntervals::read())
+    {
+        refinementDict_ = optionalSubDict(type() + "Coeffs");
+
+        //- Mandatory entries
+        refinementDict_.lookup("cellsPerProc") >> cellsPerProc_;
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+
+// ************************************************************************* //

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
@@ -64,6 +64,10 @@ class ROAMR
         
         //- Target cells per processor (default 20k)
         int cellsPerProc_;
+        
+        //- Maximum number of intervals to maintain at 
+        //  least D4sigma interval length
+        scalar maxIntervals_;
 
 public:
 

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
@@ -24,7 +24,7 @@ License
     along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
 
 Class
-    Foam::refinementControllers::uniformIntervals
+    Foam::refinementControllers::ROAMR
 
 Description
     This refinement control scheme divides the simulation into an even
@@ -33,14 +33,14 @@ Description
     interval.
 
 SourceFiles
-    uniformIntervals.C
+    ROAMR.C
 
 \*---------------------------------------------------------------------------*/
 
-#ifndef uniformIntervals_H
-#define uniformIntervals_H
+#ifndef ROAMR_H
+#define ROAMR_H
 
-#include "refinementController.H"
+#include "uniformIntervals.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -50,54 +50,40 @@ namespace refinementControllers
 {
 
 /*---------------------------------------------------------------------------*\
-                             Class uniformIntervals
+                             Class ROAMR
 \*---------------------------------------------------------------------------*/
 
-class uniformIntervals
+class ROAMR
 :
-    public refinementController
+    public uniformIntervals
 {
-    //- Private Data
+    // Private Data
     
         //- Dictionary
         dictionary coeffs_;
         
-protected:
-
-   //- Protected data
-        
-        //- Number of intervals
-        scalar intervals_;
-        
-        //- Bounding box size for beam (multiples of D1sigma)
-        scalar boundingBox_;
-        
-        //- Time duration of each interval
-        scalar intervalSize_;
-        
-        //- Time for next update
-        scalar updateTime_;
+        //- Target cells per processor (default 20k)
+        int cellsPerProc_;
 
 public:
 
     //- Runtime type information
-    TypeName("uniformIntervals");
+    TypeName("ROAMR");
 
 
     // Constructors
 
         //- Construct from components
-        uniformIntervals
+        ROAMR
         (
             const PtrList<heatSourceModel>& sources,
             const dictionary& dict,
-            const fvMesh& mesh,
-            const bool& roamr = false
+            const fvMesh& mesh
         );
 
 
     //- Destructor
-    virtual ~uniformIntervals()
+    virtual ~ROAMR()
     {}
 
 

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
@@ -45,13 +45,15 @@ Foam::refinementControllers::uniformIntervals::uniformIntervals
 (
     const PtrList<heatSourceModel>& sources,
     const dictionary& dict,
-    const fvMesh& mesh
+    const fvMesh& mesh,
+    const bool& roamr
 )
 :
     refinementController(typeName, sources, dict, mesh),
     
-    coeffs_(refinementDict_.optionalSubDict(typeName + "Coeffs")),
-    intervals_(coeffs_.lookup<int>("intervals")),
+    coeffs_(roamr ? refinementDict_.optionalSubDict("ROAMRCoeffs")
+                  : refinementDict_.optionalSubDict(typeName + "Coeffs")),
+    intervals_(roamr ? 1.0 : coeffs_.lookup<scalar>("intervals")),
     boundingBox_(coeffs_.lookupOrDefault<scalar>("boundingBox", 3)),
     intervalSize_(mesh_.time().endTime().value() / intervals_),
     updateTime_(0.0)

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
@@ -55,11 +55,24 @@ Foam::refinementControllers::uniformIntervals::uniformIntervals
                   : refinementDict_.optionalSubDict(typeName + "Coeffs")),
     intervals_(roamr ? 1.0 : coeffs_.lookup<scalar>("intervals")),
     boundingBox_(coeffs_.lookupOrDefault<scalar>("boundingBox", 3)),
-    intervalSize_(mesh_.time().endTime().value() / intervals_),
+    endTime_(mesh_.time().endTime().value()),
+    intervalSize_(endTime_ / intervals_),
     updateTime_(0.0)
 {
     //- Divide bounding box by 2, since beam dimensions are returned as D2sigma
     boundingBox_ /= 2.0;
+    
+    //- Recalculate interval size using beam end time
+    scalar beamEndTime = 0.0;
+    
+    forAll(sources_, i)
+    {
+        beamEndTime = max(beamEndTime, sources_[i].beam().endTime());
+    }
+    
+    endTime_ = min(beamEndTime, endTime_);
+    
+    intervalSize_ = endTime_ / intervals_;
 }
 
 

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.H
@@ -72,6 +72,9 @@ protected:
         //- Bounding box size for beam (multiples of D1sigma)
         scalar boundingBox_;
         
+        //- End time of scan and/or sim
+        scalar endTime_;
+        
         //- Time duration of each interval
         scalar intervalSize_;
         

--- a/tutorials/AMB2018-02-B/constant/heatSourceDict
+++ b/tutorials/AMB2018-02-B/constant/heatSourceDict
@@ -48,10 +48,16 @@ refinementControl
     
     refinementController    none;
     //refinementController    uniformIntervals;
+    //refinementController    ROAMR;
     
     uniformIntervalsCoeffs
     {
-        intervals   10;
+        intervals           10;
+    }
+    
+    ROAMRCoeffs
+    {
+        cellsPerProc        20000;
     }
 }
 


### PR DESCRIPTION
This PR implements a Resource-Optimized Adaptive Mesh Refinement (ROAMR) algorithm which dynamically scales the refinement interval to fit the allocated computational resources. The algorithm checks the number of processors available and the mesh size to maintain a specified number of cells per processor, defaulting to 20,000, in order to achieve peak computational efficiency.

The `ROAMR` refinement controller is derived from `uniformIntervals` in order to limit the amount of duplicate code. The `ROAMR` model adjusts the `intervals_` and `intervalSize_` member variables within `uniformIntervals` to allow dynamic changes in interval size. During construction, an educated guess on the interval size is made using mesh and scan path data. The interval size is then changed proportionally to the ratio of desired to actual cells, limited within +/- 10% change in interval size per function call.

Several modifications to the `uniformIntervals` and `movingBeam` class support the `ROAMR` implementation.