### PR TITLE
Resource-Optimized AMR

### DIFF
--- a/applications/solvers/additiveFoam/movingHeatSource/Make/files
+++ b/applications/solvers/additiveFoam/movingHeatSource/Make/files
@@ -16,6 +16,7 @@ refinementControllers/refinementController/refinementController.C
 refinementControllers/refinementController/refinementControllerNew.C
 refinementControllers/noRefinementController/noRefinementController.C
 refinementControllers/uniformIntervals/uniformIntervals.C
+refinementControllers/ROAMR/ROAMR.C
 
 movingHeatSourceModel/movingHeatSourceModel.C
 

--- a/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.C
@@ -55,7 +55,7 @@ Foam::movingBeam::movingBeam
     position_(Zero),
     power_(0.0),
     endTime_(0.0),
-    length_(0.0),
+    totalLength_(0.0),
     deltaT_(GREAT),
     hitPathIntervals_(true)
 {
@@ -284,7 +284,7 @@ void Foam::movingBeam::readPath()
         {
             scalar d_ = mag(path_[i].position() - path_[i-1].position());
             
-            length_ += d_;
+            totalLength_ += d_;
                     
             path_[i].setTime
             (

--- a/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.C
@@ -55,6 +55,7 @@ Foam::movingBeam::movingBeam
     position_(Zero),
     power_(0.0),
     endTime_(0.0),
+    length_(0.0),
     deltaT_(GREAT),
     hitPathIntervals_(true)
 {
@@ -282,6 +283,8 @@ void Foam::movingBeam::readPath()
         else
         {
             scalar d_ = mag(path_[i].position() - path_[i-1].position());
+            
+            length_ += d_;
                     
             path_[i].setTime
             (

--- a/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.H
@@ -88,6 +88,9 @@ private:
         //- End time of path
         scalar endTime_;
         
+        //- Total length of path
+        scalar length_;
+        
         //- Time step used for heat source integration
         scalar deltaT_;
         
@@ -165,6 +168,11 @@ public:
         inline scalar deltaT() const
         {
             return deltaT_;
+        }
+        
+        inline scalar length() const
+        {
+            return length_;
         }
 
         //- Return path end time

--- a/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/movingBeam/movingBeam.H
@@ -89,7 +89,7 @@ private:
         scalar endTime_;
         
         //- Total length of path
-        scalar length_;
+        scalar totalLength_;
         
         //- Time step used for heat source integration
         scalar deltaT_;
@@ -170,9 +170,9 @@ public:
             return deltaT_;
         }
         
-        inline scalar length() const
+        inline scalar totalLength() const
         {
-            return length_;
+            return totalLength_;
         }
 
         //- Return path end time

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.C
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2011-2022 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+                Copyright (C) 2023 Oak Ridge National Laboratory                
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+\*---------------------------------------------------------------------------*/
+
+#include "ROAMR.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace refinementControllers
+{
+    defineTypeNameAndDebug(ROAMR, 0);
+    addToRunTimeSelectionTable(refinementController, ROAMR, dictionary);
+}
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::refinementControllers::ROAMR::ROAMR
+(
+    const PtrList<heatSourceModel>& sources,
+    const dictionary& dict,
+    const fvMesh& mesh
+)
+:
+    uniformIntervals(sources, dict, mesh, true),
+
+    coeffs_(refinementDict_.optionalSubDict(typeName + "Coeffs")),
+    cellsPerProc_(coeffs_.lookupOrDefault<int>("cellsPerProc", 20000))
+{
+    Info << "Calculating initial AMR interval size..." << endl;
+
+    //- Get average cell volume and cross-sectional area
+    label totalCells = mesh_.nCells();
+    reduce(totalCells, sumOp<label>());
+    scalar vAvg = gSum(mesh_.V()) / totalCells;
+    
+    //- Calculate cross-section of bounding box
+    point bbMin = boundingBox_.min();
+    point bbMax = boundingBox_.max();
+    
+    scalar bbMaxDim = max(bbMax[0] - bbMin[0], bbMax[1] - bbMin[1]);
+    
+    scalar bbArea = bbMaxDim * abs(bbMax[2] - bbMin[2]) * sources_.size();
+    
+    //- Find longest path
+    scalar maxLen = 0.0;
+
+    forAll(sources_, i)
+    {
+        maxLen = max(sources_[i].beam().length(), maxLen);
+    }
+
+    //- Calculate maximum number of intervals or shortest interval
+    //  size to maintain at least 1 bounding box between updates
+    scalar maxIntervals = maxLen / bbMaxDim;
+    minIntervalTime_ = endTime_ / maxIntervals;
+
+    //- Calculate number of intervals to optimize cells per processor
+    scalar targetCells = Pstream::nProcs() * cellsPerProc_;
+
+    if (targetCells > totalCells)
+    {
+        intervals_ = maxLen * bbArea / vAvg
+                     / (targetCells - totalCells)
+                     * (Foam::pow(2.0, 3.0 * nLevels_) - 1.0);
+    }
+
+    //- Bound number of intervals between 1 and maxIntervals
+    intervals_ = max(min(intervals_, maxIntervals), 1.0);
+
+    Info << "Setting initial number of intervals to: " << intervals_ << endl;
+
+    //- Set number of intervals in uniformIntervals class    
+    intervalTime_ = endTime_ / intervals_;
+
+    Info << "Setting initial interval time to: " << intervalTime_ << endl;
+}
+
+
+// * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
+
+bool Foam::refinementControllers::ROAMR::update()
+{
+    if ((updateTime_ - mesh_.time().value()) < small)
+    {
+        //- Don't rescale in first few iterations
+        if (mesh_.time().timeIndex() > nLevels_)
+        {
+            //- Scale interval size based on current cells/proc
+            label totalCells = mesh_.nCells();
+            reduce(totalCells, sumOp<label>());
+            scalar currCellsPerProc = totalCells / Pstream::nProcs();
+
+            Info << "Current cells per processor: " << currCellsPerProc << endl;
+            Info << "Current interval time: " << intervalTime_ << endl;
+
+            //- Rescale interval time
+            scalar scale = min(1.1, max(0.9, cellsPerProc_ / currCellsPerProc));
+            
+            intervalTime_ *= scale;
+            
+            //- Ensure interval time is above minimum time
+            intervalTime_ = max(intervalTime_, minIntervalTime_);
+            
+            Info << "New interval time: " << intervalTime_ << endl;
+        }
+
+        //- Update refinement field using uniform intervals functions
+        uniformIntervals::update();
+    }
+
+    return true;
+}
+
+
+bool Foam::refinementControllers::ROAMR::read()
+{
+    if (uniformIntervals::read())
+    {
+        refinementDict_ = optionalSubDict(type() + "Coeffs");
+
+        //- Mandatory entries
+        refinementDict_.lookup("cellsPerProc") >> cellsPerProc_;
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+
+// ************************************************************************* //

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
@@ -9,38 +9,31 @@
 -------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
-
     OpenFOAM is free software: you can redistribute it and/or modify it
     under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
     OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
     FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
     for more details.
-
     You should have received a copy of the GNU General Public License
     along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
-
 Class
-    Foam::refinementControllers::uniformIntervals
-
+    Foam::refinementControllers::ROAMR
 Description
     This refinement control scheme divides the simulation into an even
     number of intervals equal to the simulation end time divided by the
     number of intervals. Refinement for each beam is carried out on each
     interval.
-
 SourceFiles
-    uniformIntervals.C
-
+    ROAMR.C
 \*---------------------------------------------------------------------------*/
 
-#ifndef uniformIntervals_H
-#define uniformIntervals_H
+#ifndef ROAMR_H
+#define ROAMR_H
 
-#include "refinementController.H"
+#include "uniformIntervals.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -50,58 +43,44 @@ namespace refinementControllers
 {
 
 /*---------------------------------------------------------------------------*\
-                             Class uniformIntervals
+                             Class ROAMR
 \*---------------------------------------------------------------------------*/
 
-class uniformIntervals
+class ROAMR
 :
-    public refinementController
+    public uniformIntervals
 {
     // Private Data
-    
+
         //- Dictionary
         dictionary coeffs_;
-        
-protected:
 
-    //- Protected data
-        
-        //- Number of intervals
-        scalar intervals_;
-        
-        //- User-defined bounding box for refinement around moving beam
-        //- Defaults to an inverted bounding box that is updated for each beam
-        boundBox boundingBox_;
-        
-        //- Time duration of each interval
-        scalar intervalTime_;
-        
-        //- Time for next update
-        scalar updateTime_;
+        //- Target cells per processor (default 20k)
+        int cellsPerProc_;
 
-        //- Last refinement time, beyond which, no refinement occurs
-        scalar endTime_;       
+        //- Minimum interval time to maintain at least
+        //  D4sigma between refinements
+        scalar minIntervalTime_;
 
 public:
 
     //- Runtime type information
-    TypeName("uniformIntervals");
+    TypeName("ROAMR");
 
 
     // Constructors
 
         //- Construct from components
-        uniformIntervals
+        ROAMR
         (
             const PtrList<heatSourceModel>& sources,
             const dictionary& dict,
-            const fvMesh& mesh,
-            const bool& roamr = false
+            const fvMesh& mesh
         );
 
 
     //- Destructor
-    virtual ~uniformIntervals()
+    virtual ~ROAMR()
     {}
 
 

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/ROAMR/ROAMR.H
@@ -87,7 +87,7 @@ public:
     // Member Functions
 
         //- Update the refinement marker field and return true at each interval
-        virtual bool update();
+        virtual bool update(const bool& force = false);
 
         //- Read the heatSourceProperties dictionary
         virtual bool read();

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/noRefinementController/noRefinementController.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/noRefinementController/noRefinementController.H
@@ -83,7 +83,7 @@ public:
     // Member Functions
 
         //- Always return true to allow mesh.update() to work uninterupted
-        virtual bool update()
+        virtual bool update(const bool& force = false)
         {
             return true;
         }

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/refinementController/refinementController.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/refinementController/refinementController.H
@@ -159,7 +159,7 @@ public:
         virtual void setRefinementField();
     
         //- Update refinementField and return true at specified time
-        virtual bool update() = 0;
+        virtual bool update(const bool& force = false) = 0;
 
         //- Read the heat source dictionary
         virtual bool read() = 0;

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
@@ -96,7 +96,7 @@ bool Foam::refinementControllers::uniformIntervals::update(const bool& force)
 {
     if ((updateTime_ - mesh_.time().value() < small)
         ||
-        (force == true))
+        (force))
     {
         // Update next refinement time
         updateTime_ = mesh_.time().value() + intervalTime_;

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
@@ -92,9 +92,11 @@ Foam::refinementControllers::uniformIntervals::uniformIntervals
 
 // * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * * //
 
-bool Foam::refinementControllers::uniformIntervals::update()
+bool Foam::refinementControllers::uniformIntervals::update(const bool& force)
 {
-    if ((updateTime_ - mesh_.time().value()) < small)
+    if ((updateTime_ - mesh_.time().value() < small)
+        ||
+        (force == true))
     {
         // Update next refinement time
         updateTime_ = mesh_.time().value() + intervalTime_;

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.C
@@ -50,12 +50,14 @@ Foam::refinementControllers::uniformIntervals::uniformIntervals
 (
     const PtrList<heatSourceModel>& sources,
     const dictionary& dict,
-    const fvMesh& mesh
+    const fvMesh& mesh,
+    const bool& roamr
 )
 :
     refinementController(typeName, sources, dict, mesh),
-    coeffs_(refinementDict_.optionalSubDict(typeName + "Coeffs")),
-    intervals_(coeffs_.lookup<label>("intervals")),
+    coeffs_(roamr ? refinementDict_.optionalSubDict("ROAMRCoeffs")
+                  : refinementDict_.optionalSubDict(typeName + "Coeffs")),
+    intervals_(roamr ? 1.0 : coeffs_.lookup<scalar>("intervals")),
     boundingBox_
     (
         coeffs_.lookupOrDefault<boundBox>

--- a/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.H
+++ b/applications/solvers/additiveFoam/movingHeatSource/refinementControllers/uniformIntervals/uniformIntervals.H
@@ -108,7 +108,7 @@ public:
     // Member Functions
 
         //- Update the refinement marker field and return true at each interval
-        virtual bool update();
+        virtual bool update(const bool& force = false);
 
         //- Read the heatSourceProperties dictionary
         virtual bool read();

--- a/tutorials/AMB2018-02-B/constant/heatSourceDict
+++ b/tutorials/AMB2018-02-B/constant/heatSourceDict
@@ -56,7 +56,7 @@ refinementControl
     
     ROAMRCoeffs
     {
-        cellsPerProc        20000;
+        cellsPerProc        10000;
     }
 }
 

--- a/tutorials/AMB2018-02-B/constant/heatSourceDict
+++ b/tutorials/AMB2018-02-B/constant/heatSourceDict
@@ -47,10 +47,16 @@ refinementControl
         
     refinementController    none;
     //refinementController    uniformIntervals;
+    //refinementController    ROAMR;
     
     uniformIntervalsCoeffs
     {
         intervals   5;
+    }
+    
+    ROAMRCoeffs
+    {
+        cellsPerProc        20000;
     }
 }
 


### PR DESCRIPTION
This PR implements a Resource-Optimized Adaptive Mesh Refinement (ROAMR) algorithm which dynamically scales the refinement interval to fit the allocated computational resources. The algorithm checks the number of processors available and the mesh size to maintain a specified number of cells per processor, defaulting to 10,000, in order to achieve peak computational efficiency.

The ROAMR refinement controller is derived from `uniformIntervals` in order to limit the amount of duplicate code. The `ROAMR` model adjusts the `intervalTime_` member variable within `uniformIntervals` to allow dynamic changes in interval size. During construction, an educated guess on the interval size is made using mesh and scan path data. The interval size is then changed proportionally to the ratio of desired to actual cells, limited within +/- 10% change in interval size per function call.

Several modifications to the `uniformIntervals` and `movingBeam` class support the `ROAMR` implementation.